### PR TITLE
Force collapsed navbar | Reload audio players

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -315,6 +315,7 @@
 <script>
 //import Logo from '~/components/Logo.vue'
 import Intro from '~/components/Intro.vue'
+import Vue from 'vue'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -359,7 +360,10 @@ export default {
   methods: {
     stopAllAudio() {
      //console.log("Stop All Audio!")
-     //console.log();
+     Vue.nextTick(() => {
+       Array.from(document.getElementsByTagName('audio'))
+        .forEach(audio => audio.load());
+     });
     },
     toggleModalMap(mi) {
       // ruft Modal mit dem ausgewählten Stein auf

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,6 @@
   <div id="mmok">
     <b-navbar
       v-if = "getMode != 'intro'"
-      toggleable
       fixed = "top"
       type="light"
       variant="light">


### PR DESCRIPTION
Das Attribut `toggleable` zu entfernen, genügt, um den Hamburger-Status der Navbar zu erzwingen

Die `<audio>`-Elemente haben die Methode `load`, die den Player stoppt und die Source aktualisiert.
[Browser-Support](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load)
`Vue.nextTick` sorgt dafür, dass die Aktualisierung der Player auf die Aktualisierung des `src`-Attributs wartet.